### PR TITLE
Reduce uint256 fields to smaller integer types for gas and storage savings

### DIFF
--- a/src/Payments.sol
+++ b/src/Payments.sol
@@ -15,7 +15,7 @@ interface IArbiter {
         // The actual payment amount determined by the arbiter after arbitration of a rail during settlement
         uint256 modifiedAmount;
         // The epoch up to and including which settlement should occur.
-        uint256 settleUpto;
+        uint64 settleUpto;
         // A placeholder note for any additional information the arbiter wants to send to the caller of `settleRail`
         string note;
     }
@@ -24,9 +24,9 @@ interface IArbiter {
         uint256 railId,
         uint256 proposedAmount,
         // the epoch up to and including which the rail has already been settled
-        uint256 fromEpoch,
+        uint64 fromEpoch,
         // the epoch up to and including which arbitration is requested; payment will be arbitrated for (toEpoch - fromEpoch) epochs
-        uint256 toEpoch,
+        uint64 toEpoch,
         uint256 rate
     ) external returns (ArbitrationResult memory result);
 }

--- a/src/Payments.sol
+++ b/src/Payments.sol
@@ -807,7 +807,7 @@ contract Payments is
 
         // If there is no arbiter, settle the rail immediately
         if (rail.arbiter == address(0)) {
-            (, , , , uint256 settledUpto, ) = settleRail(railId, block.number);
+            (, , , , uint256 settledUpto, ) = settleRail(railId, uint64(block.number));
             require(
                 settledUpto == block.number,
                 "failed to settle rail up to current epoch"
@@ -977,7 +977,7 @@ contract Payments is
 
     function settleRailInternal(
         uint256 railId,
-        uint256 untilEpoch,
+        uint64 untilEpoch,
         bool skipArbitration
     )
         internal
@@ -986,7 +986,7 @@ contract Payments is
             uint256 totalNetPayeeAmount,
             uint256 totalPaymentFee,
             uint256 totalOperatorCommission,
-            uint256 finalSettledEpoch,
+            uint64 finalSettledEpoch,
             string memory note
         )
     {
@@ -1013,14 +1013,14 @@ contract Payments is
         }
 
         // Calculate the maximum settlement epoch based on account lockup
-        uint256 maxSettlementEpoch;
+        uint64 maxSettlementEpoch;
         if (!isRailTerminated(rail)) {
-            maxSettlementEpoch = min(untilEpoch, payer.lockupLastSettledAt);
+            maxSettlementEpoch = min64(untilEpoch, payer.lockupLastSettledAt);
         } else {
-            maxSettlementEpoch = min(untilEpoch, rail.endEpoch);
+            maxSettlementEpoch = min64(untilEpoch, rail.endEpoch);
         }
 
-        uint256 startEpoch = rail.settledUpTo;
+        uint64 startEpoch = rail.settledUpTo;
         // Nothing to settle (already settled or zero-duration)
         if (startEpoch >= maxSettlementEpoch) {
             return (
@@ -1129,12 +1129,12 @@ contract Payments is
         uint256 totalNetPayeeAmount,
         uint256 totalPaymentFee,
         uint256 totalOperatorCommission,
-        uint256 finalEpoch,
+        uint64 finalEpoch,
         string memory regularNote,
         string memory finalizedNote
     )
         internal
-        returns (uint256, uint256, uint256, uint256, uint256, string memory)
+        returns (uint256, uint256, uint256, uint256, uint64, string memory)
     {
         // Check if rail is a terminated rail that's now fully settled
         if (
@@ -1187,8 +1187,8 @@ contract Payments is
     function _settleWithRateChanges(
         uint256 railId,
         uint256 currentRate,
-        uint256 startEpoch,
-        uint256 targetEpoch,
+        uint64 startEpoch,
+        uint64 targetEpoch,
         bool skipArbitration
     )
         internal
@@ -1207,13 +1207,13 @@ contract Payments is
         totalNetPayeeAmount = 0;
         totalPaymentFee = 0;
         totalOperatorCommission = 0;
-        uint256 processedEpoch = startEpoch;
+        uint64 processedEpoch = startEpoch;
         note = "";
 
         // Process each segment until we reach the target epoch or hit an early exit condition
         while (processedEpoch < targetEpoch) {
             // Default boundary is the target we want to reach
-            uint256 segmentEndBoundary = targetEpoch;
+            uint64 segmentEndBoundary = targetEpoch;
             uint256 segmentRate;
 
             // If we have rate changes in the queue, use the rate from the next change
@@ -1228,7 +1228,7 @@ contract Payments is
                 );
 
                 // Boundary is the minimum of our target or the next rate change epoch
-                segmentEndBoundary = min(
+                segmentEndBoundary = min64(
                     targetEpoch,
                     nextRateChange.untilEpoch
                 );
@@ -1315,8 +1315,8 @@ contract Payments is
 
     function _settleSegment(
         uint256 railId,
-        uint256 epochStart,
-        uint256 epochEnd,
+        uint64 epochStart,
+        uint64 epochEnd,
         uint256 rate,
         bool skipArbitration
     )
@@ -1336,7 +1336,7 @@ contract Payments is
         // Calculate the default settlement values (without arbitration)
         uint256 duration = epochEnd - epochStart;
         uint256 settledAmount = rate * duration;
-        uint256 settledUntilEpoch = epochEnd;
+        uint64 settledUntilEpoch = epochEnd;
         note = "";
 
         // If this rail has an arbiter and we're not skipping arbitration, let it decide on the final settlement amount
@@ -1430,9 +1430,9 @@ contract Payments is
     // returns the actual epoch upto and including which the lockup was settled
     function settleAccountLockup(
         Account storage account
-    ) internal returns (uint256) {
-        uint256 currentEpoch = block.number;
-        uint256 elapsedTime = currentEpoch - account.lockupLastSettledAt;
+    ) internal returns (uint64) {
+        uint64 currentEpoch = uint64(block.number);
+        uint64 elapsedTime = currentEpoch - account.lockupLastSettledAt;
 
         if (elapsedTime <= 0) {
             return account.lockupLastSettledAt;
@@ -1464,7 +1464,7 @@ contract Payments is
         }
 
         // Round down to the nearest whole epoch
-        uint256 fractionalEpochs = availableFunds / account.lockupRate;
+        uint64 fractionalEpochs = uint64(availableFunds / account.lockupRate);
 
         // Apply lockup up to this point
         account.lockupCurrent += account.lockupRate * fractionalEpochs;
@@ -1476,7 +1476,7 @@ contract Payments is
 
     function remainingEpochsForTerminatedRail(
         Rail storage rail
-    ) internal view returns (uint256) {
+    ) internal view returns (uint64) {
         require(isRailTerminated(rail), "rail is not terminated");
 
         // If current block beyond end epoch, return 0
@@ -1485,7 +1485,7 @@ contract Payments is
         }
 
         // Return the number of epochs (blocks) remaining until end epoch
-        return rail.endEpoch - block.number;
+        return rail.endEpoch - uint64(block.number);
     }
 
     function isRailTerminated(Rail storage rail) internal view returns (bool) {
@@ -1499,7 +1499,7 @@ contract Payments is
     // Get the final settlement epoch for a terminated rail
     function maxSettlementEpochForTerminatedRail(
         Rail storage rail
-    ) internal view returns (uint256) {
+    ) internal view returns (uint64) {
         require(isRailTerminated(rail), "rail is not terminated");
         return rail.endEpoch;
     }
@@ -1710,5 +1710,9 @@ contract Payments is
 }
 
 function min(uint256 a, uint256 b) pure returns (uint256) {
+    return a < b ? a : b;
+}
+
+function min64(uint64 a, uint64 b) pure returns (uint64) {
     return a < b ? a : b;
 }

--- a/src/Payments.sol
+++ b/src/Payments.sol
@@ -42,33 +42,48 @@ contract Payments is
     using RateChangeQueue for RateChangeQueue.Queue;
 
     // Maximum commission rate in basis points (100% = 10000 BPS)
-    uint256 public constant COMMISSION_MAX_BPS = 10000;
+    uint16 public constant COMMISSION_MAX_BPS = 10000;
 
-    uint256 public constant PAYMENT_FEE_BPS = 10; //(0.1 % fee)
+    uint16 public constant PAYMENT_FEE_BPS = 10; //(0.1 % fee)
 
     struct Account {
         uint256 funds;
         uint256 lockupCurrent;
         uint256 lockupRate;
         // epoch up to and including which lockup has been settled for the account
-        uint256 lockupLastSettledAt;
+        uint64 lockupLastSettledAt;
     }
 
     struct Rail {
+        // slot 0: 20 B + 8 B = 28 B used (4 B free)
         address token;
+        uint64 lockupPeriod;
+
+        // slot 1: 20 B + 8 B = 28 B used
         address from;
-        address to;
-        address operator;
-        address arbiter;
-        uint256 paymentRate;
-        uint256 lockupPeriod;
-        uint256 lockupFixed;
         // epoch up to and including which this rail has been settled
-        uint256 settledUpTo;
-        RateChangeQueue.Queue rateChangeQueue;
-        uint256 endEpoch; // Final epoch up to which the rail can be settled (0 if not terminated)
+        uint64 settledUpTo;
+
+        // slot 2: 20 B + 8 B = 28 B used
+        address to;
+        uint64 endEpoch; // Final epoch up to which the rail can be settled (0 if not terminated)
+
+        // slot 3: 20 B + 2 B = 22 B used
+        address operator;
         // Operator commission rate in basis points (e.g., 100 BPS = 1%)
-        uint256 commissionRateBps;
+        uint16 commissionRateBps;
+
+        // slot 4: 20 B used
+        address arbiter;
+
+        // slot 5: 32 B used
+        uint256 paymentRate;
+
+        // slot 6: 32 B used
+        uint256 lockupFixed;
+
+        // RateChangeQueue.Queue is 3×32 B (mapping + head + tail) slots 7, 8, 9
+        RateChangeQueue.Queue rateChangeQueue;
     }
 
     struct OperatorApproval {
@@ -80,7 +95,7 @@ contract Payments is
     }
 
     struct PayeeCommissionLimit {
-        uint256 maxBps;
+        uint16 maxBps;
         bool isSet;
     }
 
@@ -101,12 +116,12 @@ contract Payments is
         address operator;
         address arbiter;
         uint256 paymentRate;
-        uint256 lockupPeriod;
+        uint64 lockupPeriod;
         uint256 lockupFixed;
-        uint256 settledUpTo;
-        uint256 endEpoch;
+        uint64 settledUpTo;
+        uint64 endEpoch;
         // Operator commission rate in basis points (e.g., 100 BPS = 1%)
-        uint256 commissionRateBps;
+        uint16 commissionRateBps;
     }
 
     // token => client => operator => Approval
@@ -127,7 +142,7 @@ contract Payments is
     struct RailInfo {
         uint256 railId; // The rail ID
         bool isTerminated; // True if rail is terminated
-        uint256 endEpoch; // End epoch for terminated rails (0 for active rails)
+        uint64 endEpoch; // End epoch for terminated rails (0 for active rails)
     }
 
     // token => payee => array of railIds

--- a/src/Payments.sol
+++ b/src/Payments.sol
@@ -351,7 +351,7 @@ contract Payments is
     /// @param maxBps The maximum commission in basis points (0-10000).
     function setPayeeMaxCommission(
         address token,
-        uint256 maxBps
+        uint16 maxBps
     ) external validateNonZeroAddress(token, "token") {
         require(maxBps <= COMMISSION_MAX_BPS, "max commission exceeds maximum");
         payeeCommissionLimits[token][msg.sender] = PayeeCommissionLimit({
@@ -492,7 +492,7 @@ contract Payments is
         address from,
         address to,
         address arbiter,
-        uint256 commissionRateBps
+        uint16 commissionRateBps
     )
         external
         nonReentrant
@@ -532,7 +532,7 @@ contract Payments is
         rail.to = to;
         rail.operator = operator;
         rail.arbiter = arbiter;
-        rail.settledUpTo = block.number;
+        rail.settledUpTo = uint64(block.number);
         rail.endEpoch = 0;
         rail.commissionRateBps = commissionRateBps;
 
@@ -553,7 +553,7 @@ contract Payments is
     /// @custom:constraint Operator must have sufficient lockup allowance to cover any increases the lockup period or the fixed lockup.
     function modifyRailLockup(
         uint256 railId,
-        uint256 period,
+        uint64 period,
         uint256 lockupFixed
     )
         external
@@ -574,7 +574,7 @@ contract Payments is
 
     function modifyTerminatedRailLockup(
         Rail storage rail,
-        uint256 period,
+        uint64 period,
         uint256 lockupFixed
     ) internal {
         require(
@@ -609,7 +609,7 @@ contract Payments is
 
     function modifyNonTerminatedRailLockup(
         Rail storage rail,
-        uint256 period,
+        uint64 period,
         uint256 lockupFixed
     ) internal {
         Account storage payer = accounts[rail.token][rail.from];
@@ -769,7 +769,7 @@ contract Payments is
         uint256 newRate,
         uint256 oneTimePayment
     ) internal {
-        uint256 endEpoch = maxSettlementEpochForTerminatedRail(rail);
+        uint64 endEpoch = maxSettlementEpochForTerminatedRail(rail);
         require(
             newRate == 0 && oneTimePayment == 0,
             "for terminated rails beyond last settlement epoch, both new rate and one-time payment must be 0"
@@ -824,7 +824,7 @@ contract Payments is
             // For arbitrated rails, we need to enqueue the old rate.
             // This ensures that the old rate is applied up to and including the current block.
             // The new rate will be applicable starting from the next block.
-            rail.rateChangeQueue.enqueue(oldRate, block.number);
+            rail.rateChangeQueue.enqueue(oldRate, uint64(block.number));
         }
     }
 
@@ -929,12 +929,12 @@ contract Payments is
             uint256 totalNetPayeeAmount,
             uint256 totalPaymentFee,
             uint256 totalOperatorCommission,
-            uint256 finalSettledEpoch,
+            uint64 finalSettledEpoch,
             string memory note
         )
     {
         // Verify the current epoch is greater than the max settlement epoch
-        uint256 maxSettleEpoch = maxSettlementEpochForTerminatedRail(
+        uint64 maxSettleEpoch = maxSettlementEpochForTerminatedRail(
             rails[railId]
         );
         require(
@@ -956,7 +956,7 @@ contract Payments is
     /// @return note Additional information about the settlement (especially from arbitration).
     function settleRail(
         uint256 railId,
-        uint256 untilEpoch
+        uint64 untilEpoch
     )
         public
         nonReentrant
@@ -968,7 +968,7 @@ contract Payments is
             uint256 totalNetPayeeAmount,
             uint256 totalPaymentFee,
             uint256 totalOperatorCommission,
-            uint256 finalSettledEpoch,
+            uint64 finalSettledEpoch,
             string memory note
         )
     {

--- a/src/RateChangeQueue.sol
+++ b/src/RateChangeQueue.sol
@@ -6,7 +6,7 @@ library RateChangeQueue {
         // The payment rate to apply
         uint256 rate;
         // The epoch up to and including which this rate will be used to settle a rail
-        uint256 untilEpoch;
+        uint64 untilEpoch;
     }
 
     struct Queue {
@@ -19,7 +19,7 @@ library RateChangeQueue {
     function enqueue(
         Queue storage queue,
         uint256 rate,
-        uint256 untilEpoch
+        uint64 untilEpoch
     ) internal {
         queue.changes[queue.tail] = RateChange(rate, untilEpoch);
         queue.tail++;

--- a/test/AccountLockupSettlement.t.sol
+++ b/test/AccountLockupSettlement.t.sol
@@ -48,7 +48,7 @@ contract AccountLockupSettlementTest is Test, BaseTestHelper {
             DEPOSIT_AMOUNT * 2,
             0,
             0,
-            block.number
+            uint64(block.number)
         );
     }
 
@@ -66,7 +66,7 @@ contract AccountLockupSettlementTest is Test, BaseTestHelper {
             USER2,
             OPERATOR,
             lockupRate, // payment rate
-            lockupPeriod, // lockup period
+            uint64(lockupPeriod), // lockup period
             0, // no fixed lockup
             address(0) // no fixed lockup
         );
@@ -91,7 +91,7 @@ contract AccountLockupSettlementTest is Test, BaseTestHelper {
             DEPOSIT_AMOUNT * 2,
             expectedLockup,
             lockupRate,
-            block.number
+            uint64(block.number)
         );
     }
 
@@ -136,7 +136,7 @@ contract AccountLockupSettlementTest is Test, BaseTestHelper {
             DEPOSIT_AMOUNT, // expected funds
             expectedLockup, // expected lockup
             lockupRate, // expected lockup rate
-            expectedSettlementBlock // expected settlement block
+            uint64(expectedSettlementBlock) // expected settlement block
         );
     }
 
@@ -157,7 +157,7 @@ contract AccountLockupSettlementTest is Test, BaseTestHelper {
             USER2,
             OPERATOR,
             lockupRate, // 1 token per block
-            lockupPeriod, // Lockup period of 30 blocks
+            uint64(lockupPeriod), // Lockup period of 30 blocks
             initialLockup, // initial fixed lockup of 10 ether
             address(0) // no fixed lockup
         );
@@ -179,7 +179,7 @@ contract AccountLockupSettlementTest is Test, BaseTestHelper {
             DEPOSIT_AMOUNT * 3, // expected funds
             expectedLockup, // expected lockup
             lockupRate, // expected lockup rate
-            block.number // expected settlement block
+            uint64(block.number) // expected settlement block
         );
     }
 
@@ -208,7 +208,7 @@ contract AccountLockupSettlementTest is Test, BaseTestHelper {
             DEPOSIT_AMOUNT,
             DEPOSIT_AMOUNT,
             0, // no payment rate
-            block.number
+            uint64(block.number)
         );
 
         helper.makeDeposit(USER1, USER1, 1); // Adding more funds
@@ -259,7 +259,7 @@ contract AccountLockupSettlementTest is Test, BaseTestHelper {
             USER2,
             OPERATOR,
             lockupRate, // 1 ether per block
-            lockupPeriod, // Lockup period of 10 blocks
+            uint64(lockupPeriod), // Lockup period of 10 blocks
             initialLockup, // 50 ether fixed lockup
             address(0) // no fixed lockup
         );
@@ -285,7 +285,7 @@ contract AccountLockupSettlementTest is Test, BaseTestHelper {
             60 ether, // expected funds
             60 ether, // expected lockup
             lockupRate, // expected lockup rate
-            block.number // expected settlement block
+            uint64(block.number) // expected settlement block
         );
     }
 }

--- a/test/AccountManagement.t.sol
+++ b/test/AccountManagement.t.sol
@@ -178,7 +178,7 @@ contract AccountManagementTest is Test, BaseTestHelper {
             DEPOSIT_AMOUNT, // expected funds
             lockedAmount, // expected lockup
             0, // expected rate (not set in this test)
-            block.number // expected last settled
+            uint64(block.number) // expected last settled
         );
 
         // Try to withdraw more than unlocked funds
@@ -241,7 +241,7 @@ contract AccountManagementTest is Test, BaseTestHelper {
             DEPOSIT_AMOUNT * 2, // expected funds
             20 ether, // expected lockup (2 rails × 0.5 ether per block × 10 blocks + future lockup of 10 ether)
             lockupRate * 2, // expected rate (2 * 0.5 ether)
-            block.number // expected last settled
+            uint64(block.number) // expected last settled
         );
     }
 }

--- a/test/Fees.t.sol
+++ b/test/Fees.t.sol
@@ -162,15 +162,15 @@ contract FeesTest is Test, BaseTestHelper {
         uint256 rail1FirstExpectedAmount = RAIL1_RATE * 5; // 5 blocks * 5 ether
         
         // Settle rail1 (token1)
-        settlementHelper.settleRailAndVerify(rail1Id, block.number, rail1FirstExpectedAmount, block.number);
+        settlementHelper.settleRailAndVerify(rail1Id, uint64(block.number), rail1FirstExpectedAmount, uint64(block.number));
         
         // Settle rail2 (token2)
         vm.prank(USER1);
-        (uint256 settledAmount2,,,,, ) = payments.settleRail(rail2Id, block.number);
+        (uint256 settledAmount2,,,,, ) = payments.settleRail(rail2Id, uint64(block.number));
         
         // Settle rail3 (token3)
         vm.prank(USER1);
-        (uint256 settledAmount3,,,,, ) = payments.settleRail(rail3Id, block.number);
+        (uint256 settledAmount3,,,,, ) = payments.settleRail(rail3Id, uint64(block.number));
         
         // Calculate expected fees based on actual settled amounts (0.1% of settled amounts)
         uint256 rail1FirstFee = (rail1FirstExpectedAmount * payments.PAYMENT_FEE_BPS()) / payments.COMMISSION_MAX_BPS();
@@ -202,15 +202,15 @@ contract FeesTest is Test, BaseTestHelper {
         uint256 rail1SecondExpectedAmount = RAIL1_RATE * 7; // 7 blocks * 5 ether
         
         // Settle rail1 (token1) again
-        settlementHelper.settleRailAndVerify(rail1Id, block.number, rail1SecondExpectedAmount, block.number);
+        settlementHelper.settleRailAndVerify(rail1Id, uint64(block.number), rail1SecondExpectedAmount, uint64(block.number));
         
         // Settle rail2 (token2) again
         vm.prank(USER1);
-        (uint256 secondSettledAmount2,,,,, ) = payments.settleRail(rail2Id, block.number);
+        (uint256 secondSettledAmount2,,,,, ) = payments.settleRail(rail2Id, uint64(block.number));
         
         // Settle rail3 (token3) again
         vm.prank(USER1);
-        (uint256 secondSettledAmount3,,,,, ) = payments.settleRail(rail3Id, block.number);
+        (uint256 secondSettledAmount3,,,,, ) = payments.settleRail(rail3Id, uint64(block.number));
         
         // Calculate expected fees for second round - use actual settled amounts
         uint256 rail1SecondFee = (rail1SecondExpectedAmount * payments.PAYMENT_FEE_BPS()) / payments.COMMISSION_MAX_BPS();

--- a/test/OperatorApproval.t.sol
+++ b/test/OperatorApproval.t.sol
@@ -266,7 +266,7 @@ contract OperatorApprovalTest is Test, BaseTestHelper {
         vm.stopPrank();
 
         // 1. Set initial lockup
-        uint256 lockupPeriod = 5; // 5 blocks
+        uint64 lockupPeriod = 5; // 5 blocks
         uint256 initialFixedLockup = 100 ether;
 
         vm.startPrank(OPERATOR);
@@ -866,7 +866,7 @@ contract OperatorApprovalTest is Test, BaseTestHelper {
 
         // Set parameters for first rail
         uint256 rate1 = 10 ether;
-        uint256 lockupPeriod1 = 5;
+        uint64 lockupPeriod1 = 5;
         uint256 fixedLockup1 = 50 ether;
 
         vm.startPrank(OPERATOR);
@@ -876,7 +876,7 @@ contract OperatorApprovalTest is Test, BaseTestHelper {
 
         // Set parameters for second rail
         uint256 rate2 = 15 ether;
-        uint256 lockupPeriod2 = 3;
+        uint64 lockupPeriod2 = 3;
         uint256 fixedLockup2 = 30 ether;
 
         vm.startPrank(OPERATOR);

--- a/test/RailGetters.t.sol
+++ b/test/RailGetters.t.sol
@@ -311,7 +311,7 @@ contract PayeeRailsTest is Test, BaseTestHelper {
         );
 
         // Get the endEpoch for Rail 3
-        uint256 endEpoch;
+        uint64 endEpoch;
         for (uint256 i = 0; i < initialPayeeRails.length; i++) {
             if (initialPayeeRails[i].railId == rail3Id) {
                 endEpoch = initialPayeeRails[i].endEpoch;

--- a/test/RailSettlement.t.sol
+++ b/test/RailSettlement.t.sol
@@ -59,7 +59,7 @@ contract RailSettlementTest is Test, BaseTestHelper {
         uint256 expectedAmount = rate * 5; // 5 blocks * 5 ether
         console.log("block.number", block.number);
 
-        settlementHelper.settleRailAndVerify(railId, block.number, expectedAmount, block.number);
+        settlementHelper.settleRailAndVerify(railId, uint64(block.number), expectedAmount, uint64(block.number));
     }
 
     function testSettleRailInDebt() public {
@@ -82,10 +82,10 @@ contract RailSettlementTest is Test, BaseTestHelper {
         uint256 expectedEpoch = 2; // Initial epoch (1) + 1 epoch
         
         // First settlement
-        settlementHelper.settleRailAndVerify(railId, block.number, expectedAmount, expectedEpoch);
+        settlementHelper.settleRailAndVerify(railId, uint64(block.number), expectedAmount, uint64(expectedEpoch));
         
         // Settle again - should be a no-op since we're already settled to the expected epoch
-        settlementHelper.settleRailAndVerify(railId, block.number, 0, expectedEpoch);
+        settlementHelper.settleRailAndVerify(railId, uint64(block.number), 0, uint64(expectedEpoch));
         
         // Add more funds and settle again
         uint256 additionalDeposit = 300 ether;
@@ -95,7 +95,7 @@ contract RailSettlementTest is Test, BaseTestHelper {
         uint256 expectedAmount2 = rate * 6; // 6 more epochs * 50 ether
         
         // Third settlement
-        settlementHelper.settleRailAndVerify(railId, block.number, expectedAmount2, block.number);
+        settlementHelper.settleRailAndVerify(railId, uint64(block.number), expectedAmount2, uint64(block.number));
     }
 
     //--------------------------------
@@ -126,7 +126,7 @@ contract RailSettlementTest is Test, BaseTestHelper {
 
         // Settle with arbitration
         RailSettlementHelpers.SettlementResult memory result = 
-            settlementHelper.settleRailAndVerify(railId, block.number, expectedAmount, block.number);
+            settlementHelper.settleRailAndVerify(railId, uint64(block.number), expectedAmount, uint64(block.number));
         
         // Verify arbiter note
         assertEq(result.note, "Standard approved payment", "Arbiter note should match");
@@ -164,7 +164,7 @@ contract RailSettlementTest is Test, BaseTestHelper {
 
         // Settle with arbitration - verify against NET payee amount
         RailSettlementHelpers.SettlementResult memory result = 
-            settlementHelper.settleRailAndVerify(railId, block.number, expectedAmount, block.number);
+            settlementHelper.settleRailAndVerify(railId, uint64(block.number), expectedAmount, uint64(block.number));
         
         // Verify accumulated fees increased correctly
         uint256 feesAfter = payments.accumulatedFees(address(token));
@@ -205,7 +205,7 @@ contract RailSettlementTest is Test, BaseTestHelper {
 
         // Settle with arbitration
         RailSettlementHelpers.SettlementResult memory result = 
-            settlementHelper.settleRailAndVerify(railId, block.number, expectedAmount, expectedSettledUpto);
+            settlementHelper.settleRailAndVerify(railId, uint64(block.number), expectedAmount, uint64(expectedSettledUpto));
         
         // Verify arbiter note
         assertEq(result.note, "Arbiter reduced settlement duration", "Arbiter note should match");
@@ -233,7 +233,7 @@ contract RailSettlementTest is Test, BaseTestHelper {
         // Attempt settlement with malicious arbiter - should revert
         vm.prank(USER1);
         vm.expectRevert("arbiter settled beyond segment end");
-        payments.settleRail(railId, block.number);
+        payments.settleRail(railId, uint64(block.number));
 
         // Set the arbiter to return invalid amount but valid settlement duration
         arbiter.setMode(MockArbiter.ArbiterMode.CUSTOM_RETURN);
@@ -241,14 +241,14 @@ contract RailSettlementTest is Test, BaseTestHelper {
         uint256 invalidAmount = proposedAmount * 2; // Double the correct amount
         arbiter.setCustomValues(
             invalidAmount,
-            block.number,
+            uint64(block.number),
             "Attempting excessive payment"
         );
 
         // Attempt settlement with excessive amount - should also revert
         vm.prank(USER1);
         vm.expectRevert("arbiter modified amount exceeds maximum for settled duration");
-        payments.settleRail(railId, block.number);
+        payments.settleRail(railId, uint64(block.number));
     }
 
     //--------------------------------
@@ -257,7 +257,7 @@ contract RailSettlementTest is Test, BaseTestHelper {
 
     function testRailTerminationAndSettlement() public {
         uint256 rate = 10 ether;
-        uint256 lockupPeriod = 5;
+        uint64 lockupPeriod = 5;
         uint256 railId = helper.setupRailWithParameters(
             USER1,
             USER2,
@@ -273,7 +273,7 @@ contract RailSettlementTest is Test, BaseTestHelper {
 
         // First settlement
         uint256 expectedAmount1 = rate * 3; // 3 blocks * 10 ether
-        settlementHelper.settleRailAndVerify(railId, block.number, expectedAmount1, block.number);
+        settlementHelper.settleRailAndVerify(railId, uint64(block.number), expectedAmount1, uint64(block.number));
         
         // Terminate the rail
         vm.prank(OPERATOR);
@@ -300,7 +300,7 @@ contract RailSettlementTest is Test, BaseTestHelper {
 
         (uint256 settledAmount, uint256 netPayeeAmount, uint256 paymentFee, , uint256 settledUpto,) = 
 
-            payments.settleRail(railId, block.number);
+            payments.settleRail(railId, uint64(block.number));
         
         // Should settle up to endEpoch, which is lockupPeriod blocks after the last settlement
         uint256 expectedAmount2 = rate * lockupPeriod; // lockupPeriod = 5 blocks
@@ -334,7 +334,7 @@ contract RailSettlementTest is Test, BaseTestHelper {
 
         // Settle immediately without advancing blocks - should be a no-op
         RailSettlementHelpers.SettlementResult memory result = 
-            settlementHelper.settleRailAndVerify(railId, block.number, 0, block.number);
+            settlementHelper.settleRailAndVerify(railId, uint64(block.number), 0, uint64(block.number));
 
         console.log("result.note", result.note);
 
@@ -374,13 +374,13 @@ contract RailSettlementTest is Test, BaseTestHelper {
         );
 
         // Payee (USER2) sets a max commission limit of 5% (500 BPS)
-        uint256 payeeLimitBps = 500;
+        uint16 payeeLimitBps = 500;
         vm.startPrank(USER2);
         payments.setPayeeMaxCommission(address(token), payeeLimitBps);
         vm.stopPrank();
 
         // Attempt 1: Operator tries to create rail exceeding the limit (501 BPS)
-        uint256 exceedingCommissionBps = payeeLimitBps + 1;
+        uint16 exceedingCommissionBps = payeeLimitBps + 1;
         vm.startPrank(OPERATOR);
         vm.expectRevert(bytes("commission exceeds payee limit"));
         payments.createRail(
@@ -393,7 +393,7 @@ contract RailSettlementTest is Test, BaseTestHelper {
         vm.stopPrank();
 
         // Attempt 2: Operator tries to create rail exactly at the limit (500 BPS)
-        uint256 matchingCommissionBps = payeeLimitBps;
+        uint16 matchingCommissionBps = payeeLimitBps;
         vm.startPrank(OPERATOR);
         // This call should succeed (no revert)
         uint256 railId1 = payments.createRail(
@@ -409,7 +409,7 @@ contract RailSettlementTest is Test, BaseTestHelper {
         assertEq(rail1.commissionRateBps, matchingCommissionBps, "Rail 1 commission mismatch");
 
         // Attempt 3: Operator tries to create rail below the limit (0 BPS)
-        uint256 lowerCommissionBps = 0;
+        uint16 lowerCommissionBps = 0;
         vm.startPrank(OPERATOR);
         // This call should also succeed (no revert)
         uint256 railId2 = payments.createRail(
@@ -435,7 +435,7 @@ contract RailSettlementTest is Test, BaseTestHelper {
         );
 
         // Create rail with 2% operator commission (200 BPS)
-        uint256 operatorCommissionBps = 200;
+        uint16 operatorCommissionBps = 200;
         uint256 railId;
         vm.startPrank(OPERATOR);
         railId = payments.createRail(
@@ -449,7 +449,7 @@ contract RailSettlementTest is Test, BaseTestHelper {
 
         // Set rail parameters using modify functions
         uint256 rate = 10 ether;
-        uint256 lockupPeriod = 5;
+        uint64 lockupPeriod = 5;
         vm.startPrank(OPERATOR);
         payments.modifyRailPayment(railId, rate, 0);
         payments.modifyRailLockup(railId, lockupPeriod, 0); // no fixed lockup
@@ -468,7 +468,7 @@ contract RailSettlementTest is Test, BaseTestHelper {
         // --- Settle Rail --- 
         vm.startPrank(USER1); // Any participant can settle
         (uint256 settledAmount, uint256 netPayeeAmount, uint256 paymentFee, uint256 operatorCommission, uint256 settledUpto,) =
-            payments.settleRail(railId, block.number);
+            payments.settleRail(railId, uint64(block.number));
         vm.stopPrank();
 
         // --- Expected Calculations --- 
@@ -527,7 +527,7 @@ contract RailSettlementTest is Test, BaseTestHelper {
         helper.advanceBlocks(5);
         
         vm.prank(USER1);
-        (uint256 newSettledAmount, , uint256 newPaymentFee, , ,) = payments.settleRail(railId, block.number);
+        (uint256 newSettledAmount, , uint256 newPaymentFee, , ,) = payments.settleRail(railId, uint64(block.number));
         
         uint256 expectedNewFee = (newSettledAmount * payments.PAYMENT_FEE_BPS()) / payments.COMMISSION_MAX_BPS();
         assertEq(newPaymentFee, expectedNewFee, "New payment fee incorrect");

--- a/test/RateChangeQueue.t.sol
+++ b/test/RateChangeQueue.t.sol
@@ -26,7 +26,7 @@ contract RateChangeQueueTest is Test {
 
     function createSingleItemQueue(
         uint256 rate,
-        uint256 untilEpoch
+        uint64 untilEpoch
     ) internal returns (RateChangeQueue.RateChange memory) {
         createEmptyQueue();
         RateChangeQueue.enqueue(queue(), rate, untilEpoch);
@@ -36,7 +36,7 @@ contract RateChangeQueueTest is Test {
 
     function createMultiItemQueue(
         uint256[] memory rates,
-        uint256[] memory untilEpochs
+        uint64[] memory untilEpochs
     ) internal returns (RateChangeQueue.RateChange[] memory) {
         require(
             rates.length == untilEpochs.length,
@@ -61,7 +61,7 @@ contract RateChangeQueueTest is Test {
         createEmptyQueue();
 
         // Create cycles of filling and emptying
-        for (uint256 i = 0; i < cycles; i++) {
+        for (uint64 i = 0; i < cycles; i++) {
             // Fill with 3 items
             RateChangeQueue.enqueue(queue(), 100 + i, 5 + i);
             RateChangeQueue.enqueue(queue(), 200 + i, 6 + i);
@@ -166,7 +166,7 @@ contract RateChangeQueueTest is Test {
         rates[1] = 200;
         rates[2] = 300;
 
-        uint256[] memory epochs = new uint256[](3);
+        uint64[] memory epochs = new uint64[](3);
         epochs[0] = 5;
         epochs[1] = 10;
         epochs[2] = 15;
@@ -230,9 +230,10 @@ contract RateChangeQueueTest is Test {
 
         // Test with max uint values
         uint256 maxUint = type(uint256).max;
+        uint64 maxUint64 = type(uint64).max;
         RateChangeQueue.RateChange memory maxItem = createSingleItemQueue(
             maxUint,
-            maxUint
+            maxUint64
         );
         RateChangeQueue.RateChange memory peekedMax = RateChangeQueue.peek(
             queue()

--- a/test/helpers/PaymentsTestHelpers.sol
+++ b/test/helpers/PaymentsTestHelpers.sol
@@ -87,7 +87,7 @@ contract PaymentsTestHelpers is Test, BaseTestHelper {
             uint256 funds,
             uint256 lockupCurrent,
             uint256 lockupRate,
-            uint256 lockupLastSettledAt
+            uint64 lockupLastSettledAt
         ) = payments.accounts(address(testToken), user);
 
         return
@@ -246,7 +246,7 @@ contract PaymentsTestHelpers is Test, BaseTestHelper {
         address to,
         address railOperator,
         uint256 paymentRate,
-        uint256 lockupPeriod,
+        uint64 lockupPeriod,
         uint256 lockupFixed,
         address arbiter
     ) public returns (uint256 railId) {
@@ -455,7 +455,7 @@ contract PaymentsTestHelpers is Test, BaseTestHelper {
         uint256 expectedFunds,
         uint256 expectedLockup,
         uint256 expectedRate,
-        uint256 expectedLastSettled
+        uint64 expectedLastSettled
     ) public view {
         Payments.Account memory account = getAccountData(user);
         assertEq(account.funds, expectedFunds, "Account funds incorrect");

--- a/test/helpers/RailSettlementHelpers.sol
+++ b/test/helpers/RailSettlementHelpers.sol
@@ -144,33 +144,25 @@ contract RailSettlementHelpers is Test {
         console.log("payeeFundsBefore", payeeAccountBefore.funds);
         console.log("payeeLockupBefore", payeeAccountBefore.lockupCurrent);
 
-        uint256 settlementAmount;
-        uint256 netPayeeAmount;
-        uint256 paymentFee;
-        uint256 operatorCommission;
-        uint64 settledUpto;
-        string memory note;
-
         vm.startPrank(payer);
-        (settlementAmount, netPayeeAmount, paymentFee, operatorCommission, settledUpto, note) = payments
-            .settleRail(railId, untilEpoch);
+         (result.totalAmount, result.netPayeeAmount, result.paymentFee, result.operatorCommission, result.settledUpto, result.note) = payments.settleRail(railId, untilEpoch);
         vm.stopPrank();
 
-        console.log("settlementAmount", settlementAmount);
-        console.log("netPayeeAmount", netPayeeAmount);
-        console.log("paymentFee", paymentFee);
-        console.log("operatorCommission", operatorCommission);
-        console.log("settledUpto", settledUpto);
-        console.log("note", note);
+        console.log("settlementAmount", result.totalAmount);
+        console.log("netPayeeAmount", result.netPayeeAmount);
+        console.log("paymentFee", result.paymentFee);
+        console.log("operatorCommission", result.operatorCommission);
+        console.log("settledUpto", result.settledUpto);
+        console.log("note", result.note);
 
         // Verify results
         assertEq(
-            settlementAmount,
+            result.totalAmount,
             expectedAmount,
             "Settlement amount doesn't match expected"
         );
         assertEq(
-            settledUpto,
+            result.settledUpto,
             expectedUpto,
             "Settled upto doesn't match expected"
         );
@@ -183,19 +175,17 @@ contract RailSettlementHelpers is Test {
 
         assertEq(
             payerAccountBefore.funds - payerAccountAfter.funds,
-            settlementAmount,
+            result.totalAmount,
             "Payer's balance reduction doesn't match settlement amount"
         );
         assertEq(
             payeeAccountAfter.funds - payeeAccountBefore.funds,
-            netPayeeAmount,
+            result.netPayeeAmount,
             "Payee's balance increase doesn't match net payee amount"
         );
 
         rail = payments.getRail(railId);
         assertEq(rail.settledUpTo, expectedUpto, "Rail settled upto incorrect");
-
-        return SettlementResult(settlementAmount, netPayeeAmount, paymentFee, operatorCommission, settledUpto, note);
     }
 
     function terminateAndSettleRail(

--- a/test/helpers/RailSettlementHelpers.sol
+++ b/test/helpers/RailSettlementHelpers.sol
@@ -25,7 +25,7 @@ contract RailSettlementHelpers is Test {
         uint256 netPayeeAmount;
         uint256 paymentFee;
         uint256 operatorCommission;
-        uint256 settledUpto;
+        uint64 settledUpto;
         string note;
     }
 
@@ -35,7 +35,7 @@ contract RailSettlementHelpers is Test {
         address operator,
         address arbiter,
         uint256[] memory rates,
-        uint256 lockupPeriod,
+        uint64 lockupPeriod,
         uint256 lockupFixed
     ) public returns (uint256) {
         require(
@@ -94,7 +94,7 @@ contract RailSettlementHelpers is Test {
         address to,
         address operator,
         uint256 paymentRate,
-        uint256 lockupPeriod,
+        uint64 lockupPeriod,
         uint256 fundAmount,
         uint256 fixedLockup
     ) public returns (uint256) {
@@ -125,9 +125,9 @@ contract RailSettlementHelpers is Test {
 
     function settleRailAndVerify(
         uint256 railId,
-        uint256 untilEpoch,
+        uint64 untilEpoch,
         uint256 expectedAmount,
-        uint256 expectedUpto
+        uint64 expectedUpto
     ) public returns (SettlementResult memory result) {
         console.log("settleRailAndVerify");
         // Get the rail details to identify payer and payee
@@ -148,7 +148,7 @@ contract RailSettlementHelpers is Test {
         uint256 netPayeeAmount;
         uint256 paymentFee;
         uint256 operatorCommission;
-        uint256 settledUpto;
+        uint64 settledUpto;
         string memory note;
 
         vm.startPrank(payer);
@@ -201,7 +201,7 @@ contract RailSettlementHelpers is Test {
     function terminateAndSettleRail(
         uint256 railId,
         uint256 expectedAmount,
-        uint256 expectedUpto
+        uint64 expectedUpto
     ) public returns (SettlementResult memory result) {
         // Get rail details to extract client and operator addresses
         Payments.RailView memory rail = payments.getRail(railId);
@@ -225,7 +225,7 @@ contract RailSettlementHelpers is Test {
         return
             settleRailAndVerify(
                 railId,
-                block.number,
+                uint64(block.number),
                 expectedAmount,
                 expectedUpto
             );
@@ -236,7 +236,7 @@ contract RailSettlementHelpers is Test {
         uint256 railId,
         address operator,
         uint256 newRate,
-        uint256 newLockupPeriod,
+        uint64 newLockupPeriod,
         uint256 newFixedLockup
     ) public {
         Payments.RailView memory railBefore = paymentsContract.getRail(railId);

--- a/test/mocks/MockArbiter.sol
+++ b/test/mocks/MockArbiter.sol
@@ -15,7 +15,7 @@ contract MockArbiter is IArbiter {
     ArbiterMode public mode = ArbiterMode.STANDARD; // Default to STANDARD mode
     uint256 public modificationFactor; // Percentage (0-100) for reductions
     uint256 public customAmount;
-    uint256 public customUpto;
+    uint64 public customUpto;
     string public customNote;
 
     constructor(ArbiterMode _mode) {
@@ -31,7 +31,7 @@ contract MockArbiter is IArbiter {
     // Set custom return values for CUSTOM_RETURN mode
     function setCustomValues(
         uint256 _amount,
-        uint256 _upto,
+        uint64 _upto,
         string calldata _note
     ) external {
         customAmount = _amount;
@@ -47,8 +47,8 @@ contract MockArbiter is IArbiter {
     function arbitratePayment(
         uint256 /* railId */,
         uint256 proposedAmount,
-        uint256 fromEpoch,
-        uint256 toEpoch,
+        uint64 fromEpoch,
+        uint64 toEpoch,
         uint256 /* rate */
     ) external view override returns (ArbitrationResult memory result) {
         if (mode == ArbiterMode.STANDARD) {
@@ -69,7 +69,7 @@ contract MockArbiter is IArbiter {
         } else if (mode == ArbiterMode.REDUCE_DURATION) {
             uint256 totalEpochs = toEpoch - fromEpoch;
             uint256 reducedEpochs = (totalEpochs * modificationFactor) / 100;
-            uint256 reducedEndEpoch = fromEpoch + reducedEpochs;
+            uint64 reducedEndEpoch = uint64(fromEpoch + reducedEpochs);
 
             // Calculate reduced amount proportionally
             uint256 reducedAmount = (proposedAmount * reducedEpochs) /


### PR DESCRIPTION
Closes #75 

## Summary

Most struct fields were `uint256` even though their values never approach 2<sup>256</sup> - 1. This PR:

1. Narrows each field to the smallest unsigned integer that can hold its max value (`uint64` for epochs and `uint16` for bps.
2. Reorders fields so they tightly pack into 32-byte storage slots. 

## Changes

- `Rail` struct
    - `lockupPeriod` - `uint64`
    - `settledUpTo` - `uint64`
    - `endEpoch` - `uint64`
    - `commissionRateBps` - `uint16`

- `Account` struct
    - `lockupLastSettledAt` - `uint64`
 
- `PayeeCommissionLimit` struct
    - `maxbps` - `uint16`

- Reordered all small width fields to maximize slot packing.

## Gas and size impact

We ran `forge test --gas-report` on Foundry and compared the before/after outputs (see attached .txt files). Overall, core rail-operations (e.g. `createRail`, `getRail`, `modifyRailLockup`, `terminateRail`) saw 13–31% per-call gas savings on average and median, at the cost of a modest 0.75% increase in overall deployment cost. See details below:

| Metric                              | Before           | After            | Δ              | % Δ       |
|----------------------------------|--------------------|------------------|----------------|-----------|
| **Payments.sol** deploy cost | 4 760 515 gas| 4 796 126 gas| **+ 35 611** | **+ 0.75 %**|
| **Payments.sol** deploy size        | 21 661 bytes     | 21 825 bytes     | **+ 164** bytes | **+ 0.76 %** |
| **Fees.getAllAccumulatedFees**      | 1 198 711 gas    | 1 175 751 gas    | **– 30 974**    | **– 2.58 %** |
| **createRail** (avg)                | 207 288 gas      | 180 275 gas      | **– 27 013**         | **– 13.03 %**   |
| **createRail** (median)              | 275 281 gas      | 196 063 gas      | **– 790218**         | **– 28.77 %**   |
| **getRail** (avg)                   | 7 716 gas        | 5 659 gas        | **– 2 057**          | **– 26.65 %**   |
| **getRail** (median)                   | 8 735 gas        | 6 417 gas        | **– 2 318**         | **– 26.53 %**   |
| **modifyRailLockup** (avg)          | 73 396 gas       | 58 175 gas       | **– 15 221**         | **– 20.73 %**   |
| **modifyRailLockup** (median)          | 70 535 gas       | 50 493 gas       | **– 20 042**         | **– 28.41 %**   |
| **terminateRail** (avg)             | 51 516 gas       | 37 456 gas       | **– 14 060**         | **– 27.29 %**   |
| **terminateRail** (median)             |59 308 gas       | 40 509 gas       | **– 18 799**         | **– 31.69 %**   |
| **settleRail** (avg)                | 104 750 gas      | 101 935 gas      | **– 2 815**          | **– 2.68 %**    |
| **settleRail** (median)                | 140 446 gas      | 140 773 gas      | **+ 327**          | **+ 0.23 %**    |


[Optimized gas report (struct-packing)](https://github.com/user-attachments/files/20116173/opt-struct-packing-gas-usage.txt)
[Baseline gas report (pre-optimization)](https://github.com/user-attachments/files/20116176/prev-gas-usage.txt)

## Testing

All 79 existing Solidity tests pass unchanged.

cc @Stebalien - I've implemented the struct‐packing optimizations per #75, would love your review.