### PR TITLE
Optimize the rate-change queue

### DIFF
--- a/src/Payments.sol
+++ b/src/Payments.sol
@@ -1496,9 +1496,6 @@ contract Payments is
             "rate change queue must be empty post full settlement"
         );
 
-        // Clear the rate change queue
-        rail.rateChangeQueue.clear();
-
         rail.token = address(0);
         rail.from = address(0); // This now marks the rail as inactive
         rail.to = address(0);

--- a/test/RailSettlement.t.sol
+++ b/test/RailSettlement.t.sol
@@ -132,6 +132,48 @@ contract RailSettlementTest is Test, BaseTestHelper {
         assertEq(result.note, "Standard approved payment", "Arbiter note should match");
     }
 
+    function testArbitrationWithMultipleRateChanges() public {
+        // Deploy a standard arbiter that approves everything
+        MockArbiter arbiter = new MockArbiter(MockArbiter.ArbiterMode.STANDARD);
+
+        // Setup operator approval first
+        helper.setupOperatorApproval(
+            USER1, // from
+            OPERATOR,
+            10,
+            100 ether
+        );
+
+        // Create a rail with the arbiter
+        uint256 rate = 1;
+        uint256 expectedAmount = 0;
+        uint256 railId = helper.setupRailWithParameters(
+            USER1,
+            USER2,
+            OPERATOR,
+            rate,
+            10, // lockupPeriod
+            0, // No fixed lockup
+            address(arbiter) // Standard arbiter
+        );
+
+        vm.startPrank(OPERATOR);
+        while (rate++ < 10) {
+            // Advance several blocks
+            payments.modifyRailPayment(railId, rate, 0);
+            expectedAmount += rate * 5;
+            helper.advanceBlocks(5);
+        }
+        vm.stopPrank();
+
+        // Settle with arbitration
+        RailSettlementHelpers.SettlementResult memory result =
+            settlementHelper.settleRailAndVerify(railId, block.number, expectedAmount, block.number);
+
+         // Verify arbiter note
+         assertEq(result.note, "Standard approved payment", "Arbiter note should match");
+    }
+
     function testArbitrationWithReducedAmount() public {
         // Deploy an arbiter that reduces payment amounts
         MockArbiter arbiter = new MockArbiter(MockArbiter.ArbiterMode.REDUCE_AMOUNT);

--- a/test/RateChangeQueue.t.sol
+++ b/test/RateChangeQueue.t.sol
@@ -5,6 +5,8 @@ import {Test} from "forge-std/Test.sol";
 import {RateChangeQueue} from "../src/RateChangeQueue.sol";
 
 contract RateChangeQueueTest is Test {
+    using RateChangeQueue for RateChangeQueue.Queue;
+
     struct TestQueueContainer {
         RateChangeQueue.Queue queue;
     }
@@ -16,12 +18,10 @@ contract RateChangeQueueTest is Test {
 
     function createEmptyQueue() internal {
         // Clear any existing data
-        if (!RateChangeQueue.isEmpty(queue())) {
-            RateChangeQueue.clear(queue());
+        RateChangeQueue.Queue storage q = queue();
+        while (!q.isEmpty()) {
+            q.dequeue();
         }
-        // Verify it's empty
-        assertTrue(RateChangeQueue.isEmpty(queue()));
-        assertEq(RateChangeQueue.size(queue()), 0);
     }
 
     function createSingleItemQueue(
@@ -156,33 +156,6 @@ contract RateChangeQueueTest is Test {
         // Queue should now be empty
         assertTrue(RateChangeQueue.isEmpty(queue()));
         assertEq(RateChangeQueue.size(queue()), 0);
-    }
-
-    /// forge-config: default.allow_internal_expect_revert = true
-    function testClear() public {
-        // Setup a multi-item queue
-        uint256[] memory rates = new uint256[](3);
-        rates[0] = 100;
-        rates[1] = 200;
-        rates[2] = 300;
-
-        uint256[] memory epochs = new uint256[](3);
-        epochs[0] = 5;
-        epochs[1] = 10;
-        epochs[2] = 15;
-
-        createMultiItemQueue(rates, epochs);
-
-        // Clear the queue
-        RateChangeQueue.clear(queue());
-
-        // Verify it's empty
-        assertTrue(RateChangeQueue.isEmpty(queue()));
-        assertEq(RateChangeQueue.size(queue()), 0);
-
-        // Verify peek reverts since queue is empty
-        vm.expectRevert("Queue is empty");
-        RateChangeQueue.peek(queue());
     }
 
     /// forge-config: default.allow_internal_expect_revert = true


### PR DESCRIPTION
This stores the rate-change queue as a single dynamic array instead of a mapping. Given how both the EVM and FEVM work, there's no extra cost for sparse arrays but there is for mappings (especially in FEVM).

From EVM gas benchmarking, this doesn't appear to make much of a difference (and I'm really not clear on why) but it makes the queue take up fewer slots at the very least.

In the FVM, this should ensure that rate changes are stored adjacent to eachother making settlement less expensive.