### PR TITLE
Remove unused `INITIAL_BALANCE` constants from test contracts

### DIFF
--- a/test/AccountLockupSettlement.t.sol
+++ b/test/AccountLockupSettlement.t.sol
@@ -14,7 +14,6 @@ contract AccountLockupSettlementTest is Test, BaseTestHelper {
 
 
     // Define constants
-    uint256 internal constant INITIAL_BALANCE = 1000 ether;
     uint256 internal constant DEPOSIT_AMOUNT = 100 ether;
 
     function setUp() public {

--- a/test/OperatorApproval.t.sol
+++ b/test/OperatorApproval.t.sol
@@ -14,7 +14,6 @@ contract OperatorApprovalTest is Test, BaseTestHelper {
     MockERC20 secondToken;
     PaymentsTestHelpers helper;
     Payments payments;
-    uint256 constant INITIAL_BALANCE = 10000 ether;
     uint256 constant DEPOSIT_AMOUNT = 1000 ether;
     uint256 constant RATE_ALLOWANCE = 100 ether;
     uint256 constant LOCKUP_ALLOWANCE = 1000 ether;

--- a/test/PaymentsAccessControl.t.sol
+++ b/test/PaymentsAccessControl.t.sol
@@ -11,9 +11,6 @@ contract AccessControlTest is Test, BaseTestHelper {
     Payments payments;
     PaymentsTestHelpers helper;
 
-    
-
-    uint256 constant INITIAL_BALANCE = 1000 ether;
     uint256 constant DEPOSIT_AMOUNT = 100 ether;
     uint256 railId;
 

--- a/test/RailSettlement.t.sol
+++ b/test/RailSettlement.t.sol
@@ -17,7 +17,6 @@ contract RailSettlementTest is Test, BaseTestHelper {
     Payments payments;
     MockERC20 token;
 
-    uint256 constant INITIAL_BALANCE = 5000 ether;
     uint256 constant DEPOSIT_AMOUNT = 200 ether;
 
     function setUp() public {


### PR DESCRIPTION
This PR removes the `INITIAL_BALANCE` constants from the following test files, as they were defined but never used:

* `AccountLockupSettlement.t.sol`
* `OperatorApproval.t.sol`
* `PaymentsAccessControl.t.sol`
* `RailSettlement.t.sol`

This cleanup reduces noise and improves test readability without affecting functionality or coverage.
