### PR TITLE
Fix `setupOperatorApproval` argument count in `RailSettlement` test

### DIFF
--- a/test/RailSettlement.t.sol
+++ b/test/RailSettlement.t.sol
@@ -144,7 +144,8 @@ contract RailSettlementTest is Test, BaseTestHelper {
             USER1,
             OPERATOR,
             rateAllowance,
-            lockupAllowance
+            lockupAllowance,
+            MAX_LOCKUP_PERIOD
         );
 
         // Operator increases the payment rate from 5 ETH to 6 ETH per block for epochs (9-14)


### PR DESCRIPTION
## Description
This PR updates the `helper.setupOperatorApproval` call in `test/RailSettlement.t.sol` to include the missing `MAX_LOCKUP_PERIOD` argument, aligning the test with the helper’s 5-parameter signature and restoring successful compilation.

```diff
-           helper.setupOperatorApproval(
-            USER1,
-            OPERATOR,
-            rateAllowance,
-            lockupAllowance
-        );
+           helper.setupOperatorApproval(
+            USER1,
+            OPERATOR,
+            rateAllowance,
+            lockupAllowance,
+            MAX_LOCKUP_PERIOD
+        );
```

Closes #102 